### PR TITLE
SequentialFeatureSelection Early Stopping Criterion

### DIFF
--- a/mlxtend/feature_selection/sequential_feature_selector.py
+++ b/mlxtend/feature_selection/sequential_feature_selector.py
@@ -115,12 +115,12 @@ class SequentialFeatureSelector(_BaseXComposition, MetaEstimatorMixin):
         The number of CPUs to use for evaluating different feature subsets
         in parallel. -1 means 'all CPUs'.
     early_stop : bool (default: False)
-        Determines whether to prematurely stop execution if the score does not 
-        improve after a number of iterations set by the `early_stop_rounds` 
+        Determines whether to prematurely stop execution if the score does not
+        improve after a number of iterations set by the `early_stop_rounds`
         parameter.
     early_stop_rounds : int (default 3)
-        Used when early_stop is True, it determines the number of iterations 
-        after which, if no performance boost has been seen, execution is 
+        Used when `early_stop` is True, it determines the number of iterations
+        after which, if no performance boost has been seen, execution is
         stopped.
     pre_dispatch : int, or string (default: '2*n_jobs')
         Controls the number of jobs that get dispatched
@@ -186,7 +186,7 @@ class SequentialFeatureSelector(_BaseXComposition, MetaEstimatorMixin):
                  forward=True, floating=False,
                  verbose=0, scoring=None,
                  cv=5, n_jobs=1,
-                 early_stop=False, 
+                 early_stop=False,
                  early_stop_rounds=3,
                  pre_dispatch='2*n_jobs',
                  clone_estimator=True,

--- a/mlxtend/feature_selection/tests/test_sequential_feature_selector.py
+++ b/mlxtend/feature_selection/tests/test_sequential_feature_selector.py
@@ -983,3 +983,51 @@ def test_custom_feature_names():
     assert sfs1.k_feature_names_ == ('sepal width', 'petal width')
     assert sfs1.subsets_[2]['feature_names'] == ('sepal width',
                                                  'petal width')
+
+
+def test_run_forward_earlystop():
+    np.random.seed(0)
+    iris = load_iris()
+    X_iris = iris.data
+    y_iris = iris.target
+    X_iris_with_noise = np.concatenate(
+        (X_iris,
+         np.random.randn(X_iris.shape[0], X_iris.shape[1])),
+        axis=1)
+    knn = KNeighborsClassifier()
+    esr = 2
+    sfs = SFS(estimator=knn,
+              k_features=X_iris_with_noise.shape[1],
+              forward=True,
+              floating=False,
+              early_stop=True,
+              early_stop_rounds=esr,
+              verbose=0)
+    sfs.fit(X_iris_with_noise, y_iris)
+    assert len(sfs.subsets_) < X_iris_with_noise.shape[1]
+    assert all([sfs.subsets_[list(sfs.subsets_)[-esr-1]]['avg_score']
+               >= sfs.subsets_[i]['avg_score'] for i in sfs.subsets_.keys()])
+
+
+def test_run_backward_earlystop():
+    np.random.seed(0)
+    iris = load_iris()
+    X_iris = iris.data
+    y_iris = iris.target
+    X_iris_with_noise = np.concatenate(
+        (X_iris,
+         np.random.randn(X_iris.shape[0], X_iris.shape[1])),
+        axis=1)
+    knn = KNeighborsClassifier()
+    esr = 2
+    sfs = SFS(estimator=knn,
+              k_features=1,
+              forward=False,
+              floating=False,
+              early_stop=True,
+              early_stop_rounds=esr,
+              verbose=0)
+    sfs.fit(X_iris_with_noise, y_iris)
+    assert len(sfs.subsets_) > 1
+    assert all([sfs.subsets_[list(sfs.subsets_)[-esr-1]]['avg_score']
+               >= sfs.subsets_[i]['avg_score'] for i in sfs.subsets_.keys()])


### PR DESCRIPTION
### Description

According to some studies reported on papers (like this: https://www.researchgate.net/publication/220804144_Overfitting_in_Wrapper-Based_Feature_Subset_Selection_The_Harder_You_Try_the_Worse_it_Gets), the feature selection methodologies known as Wrapper suffer from overfitting as the number of explored states increases.
A method to reduce this overfitting is to use automatic stop criteria (early stop, as the one most known for neural networks).
In this PR I have implemented the criterion of early stopping for the class SequentialFeatureSelector.

2 parameters have been added in during instantiation of the object:
    
    early_stop : bool (default: False)
        Determines whether to prematurely stop execution if the score does not
        improve after a number of iterations set by the `early_stop_rounds`.
        parameter.
    early_stop_rounds : int (default 3)
        Used when `early_stop` is True, it determines the number of iterations
        after which, if no performance boost has been seen, execution is
        stopped.



Code Example:

```
import numpy as np
import pandas as pd
from sklearn.datasets import load_iris
from sklearn.neighbors import KNeighborsClassifier
from mlxtend.feature_selection import SequentialFeatureSelector as SFS
from mlxtend.plotting import plot_sequential_feature_selection as plot_sfs

np.random.seed(0)
iris = load_iris()
X_iris = iris.data
y_iris = iris.target

# add some noies in order to have features to discard
X_iris_with_noise = np.concatenate(
    (X_iris,
    np.random.randn(X_iris.shape[0], X_iris.shape[1])),
    axis=1)

knn = KNeighborsClassifier()
```

```
sfs = SFS(
    estimator=knn,
    k_features=X_iris_with_noise.shape[1],
    forward=True,
    early_stop=False,
    verbose=0)

sfs.fit(X_iris_with_noise, y_iris)
plot_sfs(sfs.get_metric_dict());
```
![1](https://user-images.githubusercontent.com/6131781/152164064-e3384c02-0821-4daa-a965-f3b448d451ae.png)


```
sfs = SFS(
    estimator=knn,
    k_features=X_iris_with_noise.shape[1],
    forward=True,
    early_stop=True,
    early_stop_rounds=2,
    verbose=0)

sfs.fit(X_iris_with_noise, y_iris)
plot_sfs(sfs.get_metric_dict());
```

> ... Performances not improved for 2 rounds. Stopping now!

![2](https://user-images.githubusercontent.com/6131781/152164195-ad2c6ddb-7006-4f01-9409-b9b90847ab99.png)




### Pull Request Checklist

<!--
Please fill out the following checklist if applicable. For more more information and help, please see the Contributor Documentation avaialable at http://rasbt.github.io/mlxtend/contributing/.
-->

- [ ] Added a note about the modification or contribution to the `./docs/sources/CHANGELOG.md` file (if applicable)
- [x] Added appropriate unit test functions in the `./mlxtend/*/tests` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `mlxtend/docs/sources/` (if applicable)
- [ ] Ran `PYTHONPATH='.' pytest ./mlxtend -sv` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `PYTHONPATH='.' pytest ./mlxtend/classifier/tests/test_stacking_cv_classifier.py -sv`)
- [x] Checked for style issues by running `flake8 ./mlxtend`


<!--NOTE  
Due to the improved GitHub UI, the squashing of commits is no longer necessary.
Please DO NOT SQUASH commits since they help with keeping track of the changes during the discussion).
-->
